### PR TITLE
Change SDK version check

### DIFF
--- a/src/sysinfo.cc
+++ b/src/sysinfo.cc
@@ -354,8 +354,7 @@ std::vector<CPUInfo::CacheInfo> GetCacheSizesWindows() {
     C.type = "Unknown";
     switch (cache.Type) {
 // Windows SDK version >= 10.0.26100.0
-// 0x0A000010 is the value of NTDDI_WIN11_GE
-#if NTDDI_VERSION >= 0x0A000010
+#ifdef NTDDI_WIN11_GE
       case CacheUnknown:
         break;
 #endif


### PR DESCRIPTION
Followup to #1859. When that was merged, github's windows builders were only partially updated to the new windows build tools (see [this issue](https://github.com/actions/runner-images/issues/10349) for more information). We worked around this by checking the installed SDK version in a funky way, which seems to have stopped working (#1886) now that they've [fully updated](https://github.com/actions/runner-images/pull/10862).

If we ever decide that the new SDK is a requirement to build, we can remove the check entirely and just include the code unconditionally.